### PR TITLE
Possible solution for how to make a projectile not collide with the ground (fixes #15)

### DIFF
--- a/Bullet-Inferno-test/src/se/dat255/bulletinferno/model/mock/SimpleMockProjectile.java
+++ b/Bullet-Inferno-test/src/se/dat255/bulletinferno/model/mock/SimpleMockProjectile.java
@@ -75,4 +75,8 @@ public class SimpleMockProjectile implements Projectile {
 		return null;
 	}
 
+	@Override
+	public void setCollideWithObstacles(boolean collideWithObstacles) {
+	}
+
 }

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/loadout/SpecialProjectileRain.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/loadout/SpecialProjectileRain.java
@@ -66,7 +66,8 @@ public class SpecialProjectileRain implements SpecialEffect, Timerable {
 		int index = (int) Math.ceil(Math.random() * AMOUNT_BULLETS - 1);
 		if (counter < AMOUNT_BULLETS) {
 			ProjectileType.MISSILE.releaseProjectile(physics, weapons,
-					bulletPositions.get(index), new Vector2(3, 0), playerShip);
+					bulletPositions.get(index), new Vector2(3, 0), playerShip)
+					.setCollideWithObstacles(false);
 			counter++;
 		}
 	}

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/Projectile.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/Projectile.java
@@ -55,4 +55,14 @@ public interface Projectile extends PositionEntity, Collidable, Poolable {
 	
 	public ProjectileType getType();
 
+	/**
+	 * Sets a flag for if this projectile should collide with instances of {@link Obstacle} (the
+	 * "ground" and other non-living objects).
+	 * The default value is True.
+	 * 
+	 * @param collideWithObstacles
+	 *        true if the projectile should collide with {@link Obstacle} instances.
+	 */
+	public void setCollideWithObstacles(boolean collideWithObstacles);
+
 }

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/ProjectileImpl.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/ProjectileImpl.java
@@ -1,5 +1,6 @@
 package se.dat255.bulletinferno.model.weapon;
 
+import se.dat255.bulletinferno.model.map.Obstacle;
 import se.dat255.bulletinferno.model.physics.Collidable;
 import se.dat255.bulletinferno.model.physics.PhysicsBody;
 import se.dat255.bulletinferno.model.physics.PhysicsBodyDefinition;
@@ -22,6 +23,9 @@ public class ProjectileImpl implements Projectile, PhysicsViewportIntersectionLi
 	
 	/** The EntityEnvironment instance injected at construction. */
 	private final WeaponEnvironment weapons;
+	
+	/** A flag indicating if this projectile should collide with obstacles */
+	private boolean collideWithObstacles = true;
 
 	/**
 	 * A task that when added to the Game's runLater will remove this projectile. Used to no modify
@@ -51,7 +55,7 @@ public class ProjectileImpl implements Projectile, PhysicsViewportIntersectionLi
 	@Override
 	public void init(ProjectileType type, Vector2 origin, Vector2 velocity, float damage, 
 			Teamable source, PhysicsBodyDefinition bodyDefinition) {
-		
+		collideWithObstacles = true;
 		projectileType = type;
 		this.damage = damage;
 		this.source = source;
@@ -102,7 +106,10 @@ public class ProjectileImpl implements Projectile, PhysicsViewportIntersectionLi
 	}
 
 	private boolean shouldCollide(Collidable other) {
-		return ((damage > 0 && !(other instanceof Projectile) && other != getSource())
+		if(!collideWithObstacles && (other instanceof Obstacle)) {
+			return false;
+		}
+		return ((damage > 0 && !(other instanceof Projectile) && other != getSource()) 
 				&& (!(other instanceof Teamable) || !getSource().isInMyTeam((Teamable) other)));
 	}
 
@@ -168,6 +175,11 @@ public class ProjectileImpl implements Projectile, PhysicsViewportIntersectionLi
 	@Override
 	public Vector2 getDimensions() {
 		return body.getDimensions();
+	}
+	
+	@Override
+	public void setCollideWithObstacles(boolean collideWithObstacles) {
+		this.collideWithObstacles = collideWithObstacles;
 	}
 
 }

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/ProjectileType.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/weapon/ProjectileType.java
@@ -36,14 +36,14 @@ public enum ProjectileType implements ResourceIdentifier {
 		this.bodyDefinition = bodyDefinition;
 	}
 
-	public void releaseProjectile(PhysicsEnvironment physics, WeaponEnvironment weapons,
+	public Projectile releaseProjectile(PhysicsEnvironment physics, WeaponEnvironment weapons,
 			Vector2 position,
 			Vector2 projectileVector, Teamable source) {
 
 		Projectile projectile = weapons.retrieveProjectile(ProjectileImpl.class);
 		projectile.init(this, position.cpy(), projectileVector,
 				damage, source, bodyDefinition);
-		
+		return projectile;
 	}
 	
 	public void setDamage(float damage) {


### PR DESCRIPTION
- Added a collideWithObstacles flag to ProjectileImpl, used to decide if the projectile should collide with obstacles or not.
- Added a setter for the collideWithObstacles flag to the Projectile interface.
- Made the releaseProjectile method of ProjectileType return the released projectile.
- SpecialProjectileRain now sets the collideWithObstacles flag to false on all the spawned projectiles.

See #15
