### PR TITLE
Made PlayerShip not insta-die when impact with an Enemy. (fixes #24)

### DIFF
--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/entity/PlayerShipImpl.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/entity/PlayerShipImpl.java
@@ -133,7 +133,11 @@ public class PlayerShipImpl implements PlayerShip, Timerable {
 		if (hitByOtherProjectile(other)) {
 			takeDamage(((Projectile) other).getDamage());
 		} else if (collidedWithNonTeammember(other)) {
-			die();
+			if(other instanceof Enemy) {
+				takeDamage(0.6f / takeDamageModifier);
+			} else {
+				die();
+			}
 		}
 	}
 

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/model/entity/SimpleEnemy.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/model/entity/SimpleEnemy.java
@@ -104,10 +104,21 @@ public abstract class SimpleEnemy implements Enemy, Collidable, Destructible,
 	 */
 	@Override
 	public void preCollided(Collidable other) {
-		if (isAwake && hitByOtherProjectile(other)) {
+		if(!isAwake){
+			return;
+		}
+		
+		if (hitByOtherProjectile(other)) {
 			takeDamage(((Projectile) other).getDamage());
+		} else if (hitByPlayerShip(other)) {
+			takeDamage(initialHealth);
 		}
 	}
+
+	private boolean hitByPlayerShip(Collidable other) {
+		return other instanceof PlayerShip;
+	}
+
 
 	private boolean hitByOtherProjectile(Collidable other) {
 		return other instanceof Projectile && !isInMyTeam(((Projectile) other).getSource());


### PR DESCRIPTION
- Added a check to PlayerShipImpl#preCollided, only insta-die if collided with something other than an Enemy.
- Made sure the damage taken when colliding with an enemy is not affected by the takeDamageModifier.
- Made sure enemies die when they collide with the PlayerShip. If they are not they will trigger multiple collisions, killing the player.

See #24.
