### PR TITLE
Fixed bug where player/background wasn't in view.

### DIFF
--- a/Bullet-Inferno/src/se/dat255/bulletinferno/controller/GameController.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/controller/GameController.java
@@ -291,7 +291,7 @@ public class GameController extends SimpleController {
 		graphics.screenToWorld(viewportPosition);
 		viewportDimensions = new Vector2(width, 0);
 		graphics.screenToWorld(viewportDimensions);
-
+		
 		// ...adjust dimensions to bottom left corner...
 		viewportDimensions.sub(viewportPosition);
 

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/controller/Graphics.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/controller/Graphics.java
@@ -79,6 +79,7 @@ public class Graphics {
 	public void resize(float w, float h) {
 		float width = w / h * GAME_HEIGHT;
 		worldCamera.setToOrtho(false, width, GAME_HEIGHT);
+		worldCamera.update(true);
 	}
 
 	/**
@@ -95,7 +96,7 @@ public class Graphics {
 
 		// Update the camera position
 		worldCamera.position.set(nextCameraPos.x, nextCameraPos.y, 0);
-		worldCamera.update();
+		worldCamera.update(true);
 		worldBatch.setProjectionMatrix(worldCamera.combined);
 
 		// Clear the screen every frame
@@ -159,6 +160,10 @@ public class Graphics {
 
 	/** Sets the next camera position */
 	public void setNewCameraPos(float x, float y) {
+		// Have to adjust the positions from relative to the virtual GAME_WIDTH/GAME_HEIGHT
+		// to relative to the actual viewport width/height
+		x = (x - GAME_WIDTH/2) + worldCamera.viewportWidth/2;
+		y = (y - GAME_HEIGHT/2) + worldCamera.viewportHeight/2;
 		nextCameraPos.set(x, y);
 	}
 

--- a/Bullet-Inferno/src/se/dat255/bulletinferno/view/BackgroundView.java
+++ b/Bullet-Inferno/src/se/dat255/bulletinferno/view/BackgroundView.java
@@ -82,7 +82,7 @@ public class BackgroundView implements Renderable {
 		refreshSegmentViews();
 
 		batch.disableBlending();
-		batch.draw(texture, ship.getPosition().x - ship.getDimensions().x / 2, 0, 16, 9);
+		batch.draw(texture, viewport.position.x - viewport.viewportWidth/2, 0, viewport.viewportWidth, viewport.viewportHeight);
 		batch.enableBlending();
 
 		float shipLeftX = ship.getPosition().x;


### PR DESCRIPTION
- Translated(?) between the virtual GAME_WIDTH/HEIGHT and the actual viewport size in the setNewCameraPos. This fixed the player not being fully on the screen.
- Changed the backgroundView render to use the provided viewport instead of fixed width/height.
- Made sure the frustum is also updated when the camera is updated.
